### PR TITLE
Enhance exponentiation rules

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -67,7 +67,9 @@ function rules(::Val{:BASIC})
             inv(-$a)     => -inv($a)
 
             x ^ 0      => one(x)
+            x ^ 0.0    => one(x)
             x ^ 1      => x
+            x ^ 1.0    => x
             x^a * x^b  => x^(a + b)
         ]
         TRS(

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -68,7 +68,7 @@ function rules(::Val{:BASIC})
 
             x ^ 0      => one(x)
             x ^ 1      => x
-            # x^(a + b)  => x^a * x^b  # FIXME
+            x^a * x^b  => x^(a + b)
         ]
         TRS(
             EvalRule(+),

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -106,7 +106,7 @@ end
         @test normalize(@term($y + 0 + 0)) == @term($y)
         @test normalize(@term($y * (1 + 2 - 3))) == @term(0)
         @test normalize(@term(0 + $y + 0)) == @term($y)
-        @test normalize(@term(x^0.5 * x^0.5)) == @term(x)
+        @test normalize(@term($x^0.5 * $x^0.5)) == @term($x)
     end
 
     @testset "ABSOLUTE_VALUE" begin

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -106,7 +106,7 @@ end
         @test normalize(@term($y + 0 + 0)) == @term($y)
         @test normalize(@term($y * (1 + 2 - 3))) == @term(0)
         @test normalize(@term(0 + $y + 0)) == @term($y)
-        @test normalize(@term($x^0.5 * $x^0.5)) == @term($x)
+        @test normalize(@term($(float(x))^0.5 * $(float(x))^0.5)) == @term($(float(x)))
     end
 
     @testset "ABSOLUTE_VALUE" begin

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -106,6 +106,7 @@ end
         @test normalize(@term($y + 0 + 0)) == @term($y)
         @test normalize(@term($y * (1 + 2 - 3))) == @term(0)
         @test normalize(@term(0 + $y + 0)) == @term($y)
+        @test normalize(@term(x^0.5 * x^0.5 == @term(x))
     end
 
     @testset "ABSOLUTE_VALUE" begin

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -64,7 +64,7 @@ end
 
 @testset "accuracy of standard rules" begin
     @testset "$set" for set ∈ [:BASIC, :ABSOLUTE_VALUE, :BOOLEAN, :CALCULUS, :LOGARITHM, :TRIGONOMETRY, :TYPES]
-        CASES = [-10:10;]
+        CASES = [-10.:10;]
 
         set ∈ [:CALCULUS, :LOGARITHM] && continue
 
@@ -74,7 +74,7 @@ end
 
             @testset "$rule" begin
                 for case ∈ CASES
-                    vars = Rewrite.vars(l)
+                    vars = Set(Rewrite.vars(l))
                     all(vars) do var
                         Set([case]) ⊆ Rewrite.image(var)
                     end || continue
@@ -106,7 +106,7 @@ end
         @test normalize(@term($y + 0 + 0)) == @term($y)
         @test normalize(@term($y * (1 + 2 - 3))) == @term(0)
         @test normalize(@term(0 + $y + 0)) == @term($y)
-        @test normalize(@term($(float(x))^0.5 * $(float(x))^0.5)) == @term($(float(x)))
+        @test normalize(@term($x^0.5 * $x^0.5)) == @term($x)
     end
 
     @testset "ABSOLUTE_VALUE" begin

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -74,7 +74,7 @@ end
 
             @testset "$rule" begin
                 for case ∈ CASES
-                    vars = Set(Rewrite.vars(l))
+                    vars = unique(Rewrite.vars(l))
                     all(vars) do var
                         Set([case]) ⊆ Rewrite.image(var)
                     end || continue

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -106,7 +106,7 @@ end
         @test normalize(@term($y + 0 + 0)) == @term($y)
         @test normalize(@term($y * (1 + 2 - 3))) == @term(0)
         @test normalize(@term(0 + $y + 0)) == @term($y)
-        @test normalize(@term(x^0.5 * x^0.5 == @term(x))
+        @test normalize(@term(x^0.5 * x^0.5)) == @term(x)
     end
 
     @testset "ABSOLUTE_VALUE" begin


### PR DESCRIPTION
With this change, exponents are normalized in a way more similar to other CASs. 

```julia
normalize(@term 2^0.5 * 2^0.5) == @term(2)
```