### PR TITLE
WIP Implement REPL mode for Rewrite

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -41,9 +41,19 @@ git-tree-sha1 = "af883752c4935425a3ab30031a2069254c451b8b"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 version = "0.5.0"
 
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[ReplMaker]]
+deps = ["REPL", "Test", "Unicode"]
+git-tree-sha1 = "e40e05e0dc94e12717fbc368a4977039ff472c83"
+uuid = "b873ce64-0db9-51f5-a568-4457d8e49576"
+version = "0.2.2"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -66,3 +76,6 @@ version = "0.1.0"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 SpecialSets = "c6b63f46-9023-11e8-3b28-1f7d8c94880d"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ julia> normalize(@term(diff(sin(2*$x) - log($x+$y), $x)))
 @term(2 * cos(2x) - 1 / (x + y))
 ```
 
+## REPL Mode
+Rewrite now exports a REPL mode which can be accessed by pressing the `=` key at an empty `julia>` prompt. Currently, this REPL mode simply takes code and wraps it with `@term` and `normalize`, ie.
+```julia
+@term> sin(θ)/cos(θ) 
+```
+is equivalent to
+```julia
+julia> normalize(@term sin(θ)/cos(θ))
+```
+
 
 ## Approach
 *Rewrite.jl* uses matching, normalization, and completion, which will be elaborated in the next sections.

--- a/src/Rewrite.jl
+++ b/src/Rewrite.jl
@@ -14,4 +14,6 @@ include("rules.jl")
 include("completion/Completion.jl")
 using .Completion
 
+include("replmode.jl")
+
 end # module

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -8,6 +8,6 @@ if isdefined(Base, :active_repl)
         mode_name    = "Rewrite_mode",
     ) do s
         ex = Meta.parse(s)
-        :(normalize((@term $(ex)), ruleset...))
+        :(normalize(@term $(ex)))
     end
 end

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -8,7 +8,13 @@ if isdefined(Base, :active_repl)
         mode_name    = "Rewrite_mode",
     ) do s
         exs = [Meta.parse(i) for i in split(s, "with")]
-        :(normalize((@term $(exs[1])), $(exs[2])))
+        if length(exs) == 1
+            :(normalize((@term $(exs[1]))))
+        elseif length(exs) == 2
+            :(normalize((@term $(exs[1])), $(exs[2])))
+        else
+            throw("Only one `with` statement allowed.")
+        end
     end
 end
 

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -1,18 +1,15 @@
-module replmode
+module REPLMode
 
 using ReplMaker
 
-function rewrite_parser(s)
-    ex = Meta.parse(s)
-    quote
-        normalize(@term $ex)
-    end
+initrepl(
+    prompt_text  = "@term> ",
+    prompt_color = :blue, 
+    start_key    = '=', 
+    mode_name    = "Rewrite_mode",
+) do s
+    term = convert(Term, Meta.parse(s))
+    :(normalize($term))
 end
-
-initrepl(rewrite_parser, 
-         prompt_text="@term> ",
-         prompt_color = :blue, 
-         start_key='=', 
-         mode_name="Rewrite_mode")
 
 end

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -1,0 +1,18 @@
+module replmode
+
+using ReplMaker
+
+function rewrite_parser(s)
+    ex = Meta.parse(s)
+    quote
+        normalize(@term $ex)
+    end
+end
+
+initrepl(rewrite_parser, 
+         prompt_text="@term> ",
+         prompt_color = :blue, 
+         start_key='=', 
+         mode_name="Rewrite_mode")
+
+end

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -3,11 +3,12 @@ using ReplMaker
 if isdefined(Base, :active_repl)
     initrepl(
         prompt_text  = "@term> ",
-        prompt_color = :blue, 
+        prompt_color = :cyan, 
         start_key    = '=', 
         mode_name    = "Rewrite_mode",
     ) do s
-        ex = Meta.parse(s)
-        :(normalize(@term $(ex)))
+        exs = [Meta.parse(i) for i in split(s, "with")]
+        :(normalize((@term $(exs[1])), $(exs[2])))
     end
 end
+

--- a/src/replmode.jl
+++ b/src/replmode.jl
@@ -1,15 +1,13 @@
-module REPLMode
-
 using ReplMaker
 
-initrepl(
-    prompt_text  = "@term> ",
-    prompt_color = :blue, 
-    start_key    = '=', 
-    mode_name    = "Rewrite_mode",
-) do s
-    term = convert(Term, Meta.parse(s))
-    :(normalize($term))
-end
-
+if isdefined(Base, :active_repl)
+    initrepl(
+        prompt_text  = "@term> ",
+        prompt_color = :blue, 
+        start_key    = '=', 
+        mode_name    = "Rewrite_mode",
+    ) do s
+        ex = Meta.parse(s)
+        :(normalize((@term $(ex)), ruleset...))
+    end
 end

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -148,3 +148,5 @@ end
 normalize(t::Term, ::DiffRule) = t
 vars(x::Variable) = [x]
 vars(t::Term) = [map(vars, collect(t))...;]
+
+normalize(t::Term, tup::Tuple) = normalize(t, tup...)

--- a/test/replmode.jl
+++ b/test/replmode.jl
@@ -1,4 +1,4 @@
-using Test, Unicode
+using Test
 Base.include(@__MODULE__, joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testhelpers", "FakePTYs.jl"))
 import .FakePTYs: open_fake_pty
 

--- a/test/replmode.jl
+++ b/test/replmode.jl
@@ -89,8 +89,10 @@ normalize(@term cos(x)^2 + sin(x)^2)
 out3 = run_repl_test(test_script3);
 out3p = run_repl_test(test_script3p);
 
-@testset "Repl Mode" begin
+@testset "REPL Mode" begin
     @test out1[end-7] == out1p[end-7]
+    println("Testing REPL...")  # FIXME: avoids CI timeout
     @test out2[end-7] == out2p[end-7]
+    println("Testing REPL...")  # FIXME: avoids CI timeout
     @test out3[end-7] == out3p[end-7]
 end

--- a/test/replmode.jl
+++ b/test/replmode.jl
@@ -1,0 +1,98 @@
+using Test, Unicode
+Base.include(@__MODULE__, joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testhelpers", "FakePTYs.jl"))
+import .FakePTYs: open_fake_pty
+
+slave, master = open_fake_pty()
+
+CTRL_C = '\x03'
+
+function run_repl_test(test_script)
+    slave, master = open_fake_pty()
+    # Start a julia process
+    p = run(`$(Base.julia_cmd()) --history-file=no --startup-file=no`, slave, slave, slave; wait=false)
+    
+    # Read until the prompt
+    readuntil(master, "julia>", keep=true)
+    done = false
+    repl_output_buffer = IOBuffer()
+
+    # A task that just keeps reading the output
+    @async begin
+        while true
+            done && break
+            write(repl_output_buffer, readavailable(master))
+        end
+    end
+
+    # Execute our "script"
+    for l in split(test_script, '\n'; keepempty=false)
+        write(master, l, '\n')
+    end
+
+    # Let the REPL exit
+    write(master, "exit()\n")
+    wait(p)
+    done = true
+
+    # Gather the output
+    repl_output = String(take!(repl_output_buffer))
+    println(repl_output)
+    return split(repl_output, '\n'; keepempty=false)
+end
+
+
+test_script1 = """
+using Rewrite
+
+=
+1 + 1
+"""*CTRL_C
+
+test_script1p = """
+using Rewrite
+
+normalize(@term 1 + 1)
+"""*CTRL_C
+
+test_script2 = """
+using Rewrite
+
+=
+1 + 1
+"""*CTRL_C
+
+out1 = run_repl_test(test_script1);
+out1p = run_repl_test(test_script1p);
+
+test_script2p = """
+using Rewrite
+
+normalize(@term 1 + 1)
+"""*CTRL_C
+
+out2 = run_repl_test(test_script2);
+out2p = run_repl_test(test_script2p);
+
+
+test_script3 = """
+using Rewrite
+
+=
+cos(x)^2 + sin(x)^2
+"""*CTRL_C
+
+test_script3p = """
+using Rewrite
+
+normalize(@term cos(x)^2 + sin(x)^2)
+"""*CTRL_C
+
+out3 = run_repl_test(test_script3);
+out3p = run_repl_test(test_script3p);
+
+
+
+
+@test out1[end-7] == out1p[end-7]
+@test out2[end-7] == out2p[end-7]
+@test out3[end-7] == out3p[end-7]

--- a/test/replmode.jl
+++ b/test/replmode.jl
@@ -36,7 +36,6 @@ function run_repl_test(test_script)
 
     # Gather the output
     repl_output = String(take!(repl_output_buffer))
-    println(repl_output)
     return split(repl_output, '\n'; keepempty=false)
 end
 
@@ -90,9 +89,8 @@ normalize(@term cos(x)^2 + sin(x)^2)
 out3 = run_repl_test(test_script3);
 out3p = run_repl_test(test_script3p);
 
-
-
-
-@test out1[end-7] == out1p[end-7]
-@test out2[end-7] == out2p[end-7]
-@test out3[end-7] == out3p[end-7]
+@testset "Repl Mode" begin
+    @test out1[end-7] == out1p[end-7]
+    @test out2[end-7] == out2p[end-7]
+    @test out3[end-7] == out3p[end-7]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Test
 include("patterns.jl")
 include("rules.jl")
 include("completion.jl")
+include("replmode.jl")


### PR DESCRIPTION
So currently this lets one press `=` at the repl to open a `@term>` prompt. This prompt will simply take code one supplies and wrap it with `@term` and `normalize`. Hence, `@term> 1 + 1` is equivalent to `julia> normalize(@term 1 + 1)`.

I am currently working on the next step which is to allow one to declare what set of rules one wants to do with a syntax like
```
@term> rulest TRIGONOMETRY
```
which makes 
```
@term> _______
```
parse to 
```
julia> normalise(@term(_______), :TRIGONOMETRY)
```

This next step can either be tacked onto this PR when it's done, or it can be a separate PR depending on how eager you are to merge this one. 

Ref: #27