### PR TITLE
Add predicates to PatternRule

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -13,7 +13,7 @@ function image end
 abstract type AbstractImages end
 image(::Expr, ::AbstractImages) = TypeSet(Any)
 image(x::Symbolic, ::AbstractImages) = x.image
-image(x::Variable, i::AbstractImages) = image(x.sym, i)
+image(x::Variable, i::AbstractImages) = TypeSet(Any)
 image(x, ::AbstractImages) = Set([x])
 
 struct EmptyImages <: AbstractImages end

--- a/src/match.jl
+++ b/src/match.jl
@@ -64,13 +64,9 @@ Match(Set(Dict{Variable,Any}[Dict(x=>a)]))
 """
 match(pattern::Term, subject::Term) = match(Term, get(pattern), get(subject), one(Match))
 
-function match(::Type{Term}, x::Variable, t, Θ)
-    image(t) ⊆ image(x) || return zero(Match)
-    merge(Θ, Match(x => t))
-end
+match(::Type{Term}, x::Variable, t, Θ) = merge(Θ, Match(x => t))
 function match(::Type{Term}, p::Expr, s::Expr, Θ)
     p.head === s.head   || return zero(Match)
-    image(s) ⊆ image(p) || return zero(Match)
 
     P = hasproperty(Orderless, s) ? Orderless :
         hasproperty(Flat, s)      ? Flat      :

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -57,8 +57,6 @@ rules() = [
 ]
 
 function rules(::Val{:BASIC})
-    a = Variable(:a, Nonzero)
-    b = Variable(:b, Nonzero)
     @vars x y z
 
     [
@@ -70,20 +68,20 @@ function rules(::Val{:BASIC})
             (x * y) * z => (*)(x, y, z)
 
             x - y  => x + -y
-            x / a  => x * inv(a)
+            (x / y  => x * inv(y)) where {_image(y, Nonzero)}
 
             x + -x     => zero(x)
-            a * inv(a) => one(a)
+            (x * inv(x) => one(x)) where {_image(x, Nonzero)}
 
             -(x + y)   => -y + -x
-            inv(a * b) => inv(b) * inv(a)
+            (inv(x * y) => inv(y) * inv(x)) where {_image(x, Nonzero)}
 
             -(-x)      => x
-            inv(inv(a)) => a
+            (inv(inv(x)) => x) where {_image(x, Nonzero)}
 
             -1 * x     => -x
             -x * y     => -(x * y)
-            inv(-a)     => -inv(a)
+            (inv(-x)   => -inv(x)) where {_image(x, Nonzero)}
 
             x ^ 0      => one(x)
             x ^ 0.0    => one(x)
@@ -101,14 +99,12 @@ end
 
 
 function rules(::Val{:ABSOLUTE_VALUE})
-    nn = Variable(:nn, Nonnegative)
-    neg = Variable(:neg, Negative)
     @vars x y
 
     [
         @term RULES [
-            abs(nn)     => nn
-            abs(neg)    => -neg
+            (abs(x)     =>  x)  where {_image(x, Nonnegative)}
+            (abs(x)     => -x)  where {_image(x, Negative)   }
             abs(-x)     => abs(x)
             abs(x * y)  => abs(x) * abs(y)
             abs(inv(x)) => inv(abs(x))
@@ -121,34 +117,33 @@ end
 
 
 function rules(::Val{:BOOLEAN}; and=&, or=|, neg=!)
-    x = Variable(:x, TypeSet(Bool))
-    y = Variable(:y, TypeSet(Bool))
-    z = Variable(:z, TypeSet(Bool))
+    @vars x y z
+    _bool(xs...) = σ -> all(x -> image(σ[x]) ⊆ TypeSet(Bool), xs)
 
     [
         @term RULES [
-            and(x, and(y, z)) => and(x, y, z)
-            and(and(x, y), z) => and(x, y, z)
+            (and(x, and(y, z)) => and(x, y, z))  where {_bool(x, y, z)}
+            (and(and(x, y), z) => and(x, y, z))  where {_bool(x, y, z)}
 
-            or(x, or(y, z)) => or(x, y, z)
-            or(or(x, y), z) => or(x, y, z)
+            (or(x, or(y, z)) => or(x, y, z))  where {_bool(x, y, z)}
+            (or(or(x, y), z) => or(x, y, z))  where {_bool(x, y, z)}
 
-            or(x, false) => x
-            and(x, true) => x
+            (or(x, false) => x)  where {_bool(x)}
+            (and(x, true) => x)  where {_bool(x)}
 
-            or(x, true)   => true
-            and(x, false) => false
+            (or(x, true)   => true )  where {_bool(x)}
+            (and(x, false) => false)  where {_bool(x)}
 
-            or(x, x)  => x
-            and(x, x) => x
+            (or(x, x)  => x)  where {_bool(x)}
+            (and(x, x) => x)  where {_bool(x)}
 
-            or(x, and(x, y)) => x
-            and(x, or(x, y)) => x
+            (or(x, and(x, y)) => x)  where {_bool(x, y)}
+            (and(x, or(x, y)) => x)  where {_bool(x, y)}
 
-            or(x, neg(x))  => true
-            and(x, neg(x)) => false
+            (or(x, neg(x))  => true )  where {_bool(x)}
+            (and(x, neg(x)) => false)  where {_bool(x)}
 
-            neg(neg(x)) => x
+            (neg(neg(x)) => x)  where {_bool(x)}
         ];
         TRS(
             EvalRule(and, &),
@@ -197,16 +192,16 @@ end
 
 
 function rules(::Val{:LOGARITHM})
-    m = Variable(:m, NotEqual(1))
-    n = Variable(:n, NotEqual(0, 1))
+    n1  = NotEqual(1)
+    n01 = NotEqual(0, 1)
 
     @vars x y r a b c
 
     @term RULES [
-        log(n, n) => 1
-        log(m, 1) => 0
+        (log(b, b) => 1)  where {_image(b, n01)}
+        (log(b, 1) => 0)  where {_image(b,  n1)}
 
-        log(n, n ^ x) => x
+        (log(b, b ^ x) => x)  where {_image(b, n01)}
         b ^ log(b, x) => x
 
         log(b, x ^ r) => r * log(b, x)
@@ -219,8 +214,6 @@ function rules(::Val{:LOGARITHM})
 end
 
 function rules(::Val{:TRIGONOMETRY})
-    x = Variable(:x, Nonzero)
-
     @vars α β θ
 
     @term RULES [
@@ -265,9 +258,9 @@ function rules(::Val{:TRIGONOMETRY})
         sin(-θ) => -sin(θ)
         cos(-θ) => cos(θ)
         tan(-θ) => -tan(θ)
-        csc(-x) => -csc(x)
+        (csc(-θ) => -csc(θ))  where {_image(θ, Nonzero)}
         sec(-θ) => sec(θ)
-        cot(-x) => -cot(x)
+        (cot(-θ) => -cot(θ))  where {_image(θ, Nonzero)}
 
         # Periodic formulae
         #=
@@ -309,40 +302,45 @@ function rules(::Val{:TRIGONOMETRY})
         sin(π * inv(2) + -θ) => cos(θ)
         cos(π * inv(2) + -θ) => sin(θ)
         csc(π * inv(2) + -θ) => sec(θ)
-        sec(π * inv(2) + -x) => csc(x)
-        tan(π * inv(2) + -x) => cot(x)
+        (sec(π * inv(2) + -θ) => csc(θ))  where {_image(θ, Nonzero)}
+        (tan(π * inv(2) + -θ) => cot(θ))  where {_image(θ, Nonzero)}
         cot(π * inv(2) + -θ) => tan(θ)
     ]
 end
 
 function rules(::Val{:TYPES})
-    rules = []
+    @vars x
 
+    rs = []
     types = [Number, Int, Float64]
     for T ∈ types
-        x = Variable(:x ,TypeSet(T))
+        T_ = TypeSet(T)
 
-        push!(rules, @term(zero(x)) => @term(zero(T)))
-        push!(rules, @term(x + zero(x)) => @term(x))
-        push!(rules, @term(x + $(zero(T))) => @term(x))
-        push!(rules, @term(-($(zero(T)))) => @term($(zero(T))))
+        push!(rs, @term RULES [
+            (zero(x)        => zero(T)   ) where {_image(x, T_)}
+            (x + zero(x)    => x         ) where {_image(x, T_)}
+            (x + $(zero(T)) => x         ) where {_image(x, T_)}
+            (-($(zero(T)))  => $(zero(T)))
 
-        push!(rules, @term(one(x)) => @term(one(T)))
-        push!(rules, @term(x * one(x)) => @term(x))
-        push!(rules, @term(one(x) * x) => @term(x))
-        push!(rules, @term(x * $(one(T))) => @term(x))
-        push!(rules, @term($(one(T)) * x) => @term(x))
-        push!(rules, @term(inv($(one(T)))) => @term($(one(T))))
+            (one(x)         => one(T)    ) where {_image(x, T_)}
+            (x * one(x)     => x         ) where {_image(x, T_)}
+            (x * $(one(T))  => x         ) where {_image(x, T_)}
+            (one(x) * x     => x         ) where {_image(x, T_)}
+            ($(one(T)) * x  => x         ) where {_image(x, T_)}
+            (inv($(one(T))) => $(one(T)) )
 
-        push!(rules, @term(x * zero(x)) => @term(zero(x)))
-        push!(rules, @term(zero(x) * x) => @term(zero(x)))
-        push!(rules, @term(x * $(zero(T))) => @term($(zero(T))))
-        push!(rules, @term($(zero(T)) * x) => @term($(zero(T))))
+            (x * zero(x)    => zero(x)   ) where {_image(x, T_)}
+            (x * $(zero(T)) => $(zero(T))) where {_image(x, T_)}
+            (zero(x) * x    => zero(x)   ) where {_image(x, T_)}
+            ($(zero(T)) * x => $(zero(T))) where {_image(x, T_)}
+        ])
     end
 
-    TRS(
-        rules...,
-        EvalRule(zero),
-        EvalRule(one),
-    )
+    [
+        rs...
+        TRS(
+            EvalRule(zero),
+            EvalRule(one),
+        )
+    ]
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -71,10 +71,9 @@ end
 
 
 struct Variable
-    sym::Symbolic
-    Variable(args...) = new(Symbolic(args...))
+    name::Symbol
 end
-Base.show(io::IO, x::Variable) = show(io, x.sym)
+Base.show(io::IO, x::Variable) = print(io, x.name)
 macro vars(xs::Symbol...)
     vars = (:($x = $(Variable(x))) for x ∈ xs)
     results = Expr(:tuple, xs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,3 +12,6 @@ vars(t::Term) = vars(get(t))
 vars(x::Variable) = [x]
 vars(t::Expr) = [vars.(t.args)...;]
 vars(x) = []
+
+
+_image(x, S) = σ -> image(σ[x]) ⊆ S

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -24,8 +24,8 @@ using SpecialSets
 
     @testset "Variable" begin
         @test x == x
+        @test x == Variable(:x)
         @test x ≠ y
-        @test x ≠ Variable(:x)
 
         @test match(@term(x), @term(y)) == Match(x => y)
         @test @term(y) ⊆ @term(x)
@@ -33,19 +33,6 @@ using SpecialSets
         @test replace(@term(x), Dict(x => y)) == @term(y)
         @test replace(@term(x), Dict(y => x)) == @term(x)
         @test replace(@term(x), Dict(y => z)) == @term(x)
-
-        @testset "Predicates" begin
-            nz = Variable(:nz, Nonzero)
-            p  = Variable(:p, Positive)
-            n  = Variable(:n, Negative)
-
-            @test match(@term(nz), @term(nz))         == Match(nz => nz)
-            @test match(@term(nz / nz), @term(3 / 3)) == Match(nz => 3)
-            @test match(@term(nz / nz), @term(2 / 3)) == zero(Match)
-            @test match(@term(nz / nz), @term(p))     == zero(Match)
-            @test match(@term(nz / nz), @term(p / p)) == Match(nz => p)
-            @test match(@term(nz / nz), @term(n / p)) == zero(Match)
-        end
     end
 
     @testset "Constant" begin


### PR DESCRIPTION
Generalize current image strategies to work with predicates. Each predicate takes in a substitution dictionary and checks if the matches for variables satisfy some constraint.

Predicates may be viewed as premises of an inference rule, with the rewrite step as the conclusion. For example:
```
image(x) ⊆ Nonnegative
----------------------
     abs(x) → x
```