### PR TITLE
Clean up abstract rule definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ julia> normalize(@term(y^(6 - 3log(x, x^2))))
 @term((^)(y, (+)((-)((*)(6, (log)(x, x))), 6)))
 ```
 
-In many cases, it is useful to specify entirely custom rules by passing a Term Rewriting System as the second argument to `normalize`. This may be done either by manually constructing a `TRS` object or by using the `RULES` strategy for `@term`.
+In many cases, it is useful to specify entirely custom rules by passing a Term Rewriting System as the second argument to `normalize`. This may be done either by manually constructing a `Rules` object or by using the `RULES` strategy for `@term`.
 ```julia
 julia> @syms f g h;
        @vars x;
@@ -40,7 +40,7 @@ julia> normalize(@term(f(x, f(y, y))), @term RULES [
       ])
 @term(x)
 
-julia> normalize(@term(f(g(f(1), h()))), TRS(
+julia> normalize(@term(f(g(f(1), h()))), Rules(
           @term(f(x)) => @term(x),
           @term(h())  => @term(3),
       ))
@@ -48,7 +48,7 @@ julia> normalize(@term(f(g(f(1), h()))), TRS(
 
 julia> using Rewrite: EvalRule
 
-julia> normalize(@term(f(g(f(1), h()))), TRS(
+julia> normalize(@term(f(g(f(1), h()))), Rules(
           @term(f(x)) => @term(x),
           @term(h())  => @term(3),
           EvalRule(g, (a, b) -> 2a + b)
@@ -154,15 +154,16 @@ match(b, x - 1) => match
 An expression can be **normalized** to a normal form given a set of rewrite rules.
 
 #### Example
+Let `rs` contain two rules:
 ```
-Let TRS contain two rules:
   rule 1: sin(a)^2 + cos(a)^2 => one(a)
   rule 2: log(a, b) * log(b, c) => log(a, c)
-
-normalize(log(2, sin(x)^2 + cos(x)^2 + y) * log(y + 1, z), TRS)
-  => log(2, (sin(x)^2 + cos(x)^2) + y) * log(y + 1, z)        + is associative
-  => log(2, 1 + y) * log(y + 1, z)                            rule 1
-  => log(2, y + 1) * log(y + 1, z)                            + is commutative
-  => log(2, z)                                                rule 2
 ```
-In this example, `log(2, z)` is the normal form of `log(2, sin(x)^2 + cos(x)^2 + y) * log(y + 1, z)` given the rule set `TRS`.
+```
+normalize(log(2, sin(x)^2 + cos(x)^2 + y) * log(y + 1, z), rs)
+  => log(2, (sin(x)^2 + cos(x)^2) + y) * log(y + 1, z)     #  + is associative
+  => log(2, 1 + y) * log(y + 1, z)                         #  rule 1
+  => log(2, y + 1) * log(y + 1, z)                         #  + is commutative
+  => log(2, z)                                             #  rule 2
+```
+In this example, `log(2, z)` is the normal form of `log(2, sin(x)^2 + cos(x)^2 + y) * log(y + 1, z)` given the rule set `rs`.

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -39,17 +39,6 @@ normalize(t::Term, sets::Symbol...) = normalize(t, vcat(rules.(sets)...))
 normalize(t::Term) = normalize(t, rules())
 
 
-
-struct DivergentError <: Exception
-    forms::Vector{Term}
-end
-DivergentError(forms::Term...) = DivergentError(collect(forms))
-function Base.showerror(io::IO, err::DivergentError)
-    print(io, "DivergentError: ")
-    join(io, err.forms, ", ")
-end
-
-
 struct PatternRule <: Rule
     left::Term
     right::Term

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -1,38 +1,35 @@
 using DiffRules
 
-export TermRewritingSystem, TRS
+export Rules
 export normalize
 
 
-abstract type Rule{T} end
+abstract type Rule end
 
 
-struct AbstractRewritingSystem{T}
-    rules::Vector{Rule{T}}
+struct Rules
+    rules::Vector{Rule}
+    Rules(rs::Vector{Rule}) = new(rs)
 end
-AbstractRewritingSystem{T}(rs::Union{Rule,Pair}...) where {T} =
-    AbstractRewritingSystem{T}(collect(rs))
-Base.:(==)(a::AbstractRewritingSystem, b::AbstractRewritingSystem) = a.rules == b.rules
-Base.iterate(ars::AbstractRewritingSystem) = iterate(ars.rules)
-Base.iterate(ars::AbstractRewritingSystem, state) = iterate(ars.rules, state)
-Base.length(ars::AbstractRewritingSystem) = length(ars.rules)
-Base.getindex(ars::AbstractRewritingSystem, ind) = getindex(ars.rules, ind)
-Base.push!(ars::AbstractRewritingSystem, rule) = (push!(ars.rules, rule); ars)
-Base.pushfirst!(ars::AbstractRewritingSystem, rule) = (push!(ars.rules, rule); ars)
-Base.pop!(ars::AbstractRewritingSystem) = pop!(ars.rules)
-Base.popfirst!(ars::AbstractRewritingSystem) = popfirst!(ars.rules)
-Base.deleteat!(ars::AbstractRewritingSystem, ind) = (deleteat!(ars.rules, ind); ars)
-Base.vcat(arss::AbstractRewritingSystem{T}...) where {T} = AbstractRewritingSystem([(ars.rules for ars ∈ arss)...;])
-
-const TermRewritingSystem = AbstractRewritingSystem{Term}
-const TRS = TermRewritingSystem
+Rules(rs...) = Rules(collect(Rule, rs))
+Base.:(==)(a::Rules, b::Rules) = a.rules == b.rules
+Base.iterate(rs::Rules) = iterate(rs.rules)
+Base.iterate(rs::Rules, state) = iterate(rs.rules, state)
+Base.length(rs::Rules) = length(rs.rules)
+Base.getindex(rs::Rules, ind) = getindex(rs.rules, ind)
+Base.push!(rs::Rules, rule) = (push!(rs.rules, rule); rs)
+Base.pushfirst!(rs::Rules, rule) = (push!(rs.rules, rule); rs)
+Base.pop!(rs::Rules) = pop!(rs.rules)
+Base.popfirst!(rs::Rules) = popfirst!(rs.rules)
+Base.deleteat!(rs::Rules, ind) = (deleteat!(rs.rules, ind); rs)
+Base.vcat(rss::Rules...) = Rules([(rs.rules for rs ∈ rss)...;])
 
 
-normalize(ars::AbstractRewritingSystem) = Base.Fix2(normalize, ars)
-function normalize(t::Term, trs::TermRewritingSystem)
+normalize(rs::Rules) = Base.Fix2(normalize, rs)
+function normalize(t::Term, rs::Rules)
     while true
-        t = map(normalize(trs), t)  # FIXME: replace with `subexpressions`
-        t′ = foldl(normalize, trs; init=t)
+        t = map(normalize(rs), t)  # FIXME: replace with `subexpressions`
+        t′ = foldl(normalize, rs; init=t)
         t == t′ && return t
         t = t′
     end
@@ -53,23 +50,20 @@ function Base.showerror(io::IO, err::DivergentError)
 end
 
 
-struct PatternRule{T} <: Rule{T}
-    left::T
-    right::T
+struct PatternRule <: Rule
+    left::Term
+    right::Term
     ps::Vector{Function}
 end
-PatternRule{T}(l, r) where {T} = PatternRule{T}(l, r, [])
-PatternRule{T}((l, r)::Pair{<:T,<:T}) where {T} = PatternRule{T}(l, r)
-PatternRule(l::L, r::R) where {L,R} = PatternRule{promote_type(L,R)}(l, r)
+PatternRule(l, r) = PatternRule(l, r, [])
 PatternRule((l, r)::Pair) = PatternRule(l, r)
-Base.convert(::Type{PR}, p::Pair) where {PR<:PatternRule} = PR(p)
-Base.convert(::Type{Rule{T}}, p::Pair) where {T} = convert(PatternRule{T}, p)
+Base.convert(::Type{PatternRule}, p::Pair) = PatternRule(p)
 Base.convert(::Type{Rule}, p::Pair) = convert(PatternRule, p)
 Base.convert(::Type{Pair}, r::PatternRule) = r.left => r.right
 Base.:(==)(a::PatternRule, b::PatternRule) = (a.left, a.right) == (b.left, b.right)
-Base.hash(p::PatternRule{T}, h::UInt) where {T} = hash((p.left, p.right), hash(PatternRule{T}, h))
-Base.map(f, r::PatternRule{T}) where {T} = PatternRule{T}(f(r.left), f(r.right))
-function normalize(t::T, r::PatternRule{U}) where {U,T<:U}
+Base.hash(p::PatternRule, h::UInt) = hash((p.left, p.right), hash(PatternRule, h))
+Base.map(f, r::PatternRule) = PatternRule(f(r.left), f(r.right), r.ps)
+function normalize(t::Term, r::PatternRule)
     Θ = match(r.left, t) |> collect
     isempty(Θ) && return t
 
@@ -82,7 +76,7 @@ end
 _preds_match(ps, σ) = all(p -> p(σ), ps)
 _preds_match(ps) = Base.Fix1(_preds_match, ps)
 
-struct EvalRule <: Rule{Term}
+struct EvalRule <: Rule
     name
     f
 end
@@ -132,7 +126,7 @@ function _apply_associative!(r::EvalRule, args)
 end
 
 
-struct OrderRule <: Rule{Term}
+struct OrderRule <: Rule
     by::Function
 end
 normalize(t::Term, r::OrderRule) = Term(normalize(get(t), r))
@@ -147,7 +141,7 @@ end
 normalize(x, ::OrderRule) = x
 
 
-struct DiffRule <: Rule{Term} end
+struct DiffRule <: Rule end
 normalize(t::Term, r::DiffRule) = Term(normalize(get(t), r))
 function normalize(ex::Expr, r::DiffRule)
     fn = ex.args[1]

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -37,9 +37,9 @@ macro term(::Val{:RULES}, ex)
         p, a, b = pair.args
         @assert p == :(=>)
 
-        esc(:($(PatternRule{Term})(@term($a), @term($b), $ps)))
+        esc(:($PatternRule(@term($a), @term($b), $ps)))
     end
-    :(TermRewritingSystem([$(args...)]))
+    :(Rules($Rule[$(args...)]))
 end
 
 
@@ -86,7 +86,7 @@ function rules(::Val{:BASIC})
             x ^ 1      => x
             x ^ 1.0    => x
         ]
-        TRS(
+        Rules(
             OrderRule(x -> sprint(show, x)),
             EvalRule(+),
             EvalRule(-),
@@ -107,7 +107,7 @@ function rules(::Val{:ABSOLUTE_VALUE})
             abs(x * y)  => abs(x) * abs(y)
             abs(inv(x)) => inv(abs(x))
         ]
-        TRS(
+        Rules(
             EvalRule(abs),
         )
     ]
@@ -143,7 +143,7 @@ function rules(::Val{:BOOLEAN}; and=&, or=|, neg=!)
 
             (neg(neg(x)) => x)  where {_bool(x)}
         ];
-        TRS(
+        Rules(
             EvalRule(and, &),
             EvalRule(or,  |),
             EvalRule(neg, !),
@@ -181,7 +181,7 @@ function rules(::Val{:CALCULUS})
 
     @vars x
 
-    TRS(
+    Rules(
         rules...,
         @term(diff(x, x)) => @term(one(x)),
         DiffRule(),
@@ -336,7 +336,7 @@ function rules(::Val{:TYPES})
 
     [
         rs...
-        TRS(
+        Rules(
             EvalRule(zero),
             EvalRule(one),
         )

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -10,14 +10,14 @@ using SpecialSets
 @testset "Rule" begin
 
     @testset "PatternRule" begin
-        @test normalize(@term(f(a, 0)), PatternRule{Term}(@term(f(x, 0)), @term(x))) == @term(a)
-        @test normalize(@term(a + 0), PatternRule{Term}(@term(x + 0), @term(x))) == @term(a)
-        @test normalize(@term(b + 1), PatternRule{Term}(@term(x + 0), @term(x))) == @term(b + 1)
-        @test normalize(@term(b), PatternRule{Term}(@term(x + 0), @term(x))) == @term(b)
-        @test normalize(@term(f(a, b)), TRS(@term(f(x, y)) => @term(g(x)))) == @term(g(a))
+        @test normalize(@term(f(a, 0)), PatternRule(@term(f(x, 0)), @term(x))) == @term(a)
+        @test normalize(@term(a + 0), PatternRule(@term(x + 0), @term(x))) == @term(a)
+        @test normalize(@term(b + 1), PatternRule(@term(x + 0), @term(x))) == @term(b + 1)
+        @test normalize(@term(b), PatternRule(@term(x + 0), @term(x))) == @term(b)
+        @test normalize(@term(f(a, b)), Rules(@term(f(x, y)) => @term(g(x)))) == @term(g(a))
 
         @testset "Predicates" begin
-            trs = TRS(PatternRule{Term}(
+            trs = Rules(PatternRule(
                 @term(x / x),
                 @term(one(x)),
                 [σ -> isvalid(Image(σ[x], Nonzero))]
@@ -54,9 +54,9 @@ using SpecialSets
         @test normalize(@term(f(2, b)), EvalRule(f, *)) == @term(f(2, b))
         @test normalize(@term("a" * "b"), EvalRule(*)) == @term("ab")
         @test normalize(@term(a + 2 * 3), EvalRule(*)) == @term(a + 2 * 3)
-        @test normalize(@term(a + 2 * 3), TRS(EvalRule(*))) == @term(a + 6)
-        @test normalize(@term(2 * 3 + 4 * 5), TRS(EvalRule(*))) == @term(6 + 20)
-        @test normalize(@term(2 * 3 + 4 * 5), TRS(EvalRule(+), EvalRule(*))) == @term(26)
+        @test normalize(@term(a + 2 * 3), Rules(EvalRule(*))) == @term(a + 6)
+        @test normalize(@term(2 * 3 + 4 * 5), Rules(EvalRule(*))) == @term(6 + 20)
+        @test normalize(@term(2 * 3 + 4 * 5), Rules(EvalRule(+), EvalRule(*))) == @term(26)
 
         with_context(Context(Associative(f))) do
             rule = EvalRule(f, +)


### PR DESCRIPTION
Assumed to be parameterized on `Term` and renamed to `Rules`.