### PR TITLE
Memoize the `normalize` function

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -18,7 +18,7 @@ deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[Libdl]]
@@ -35,11 +35,17 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[Memoize]]
+deps = ["Test"]
+git-tree-sha1 = "d9683969337ad20dc957122038bd2c0ead4b5209"
+uuid = "c03570c3-d221-55d1-a50c-7939bbd78826"
+version = "0.3.0"
+
 [[Polynomials]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "af883752c4935425a3ab30031a2069254c451b8b"
+git-tree-sha1 = "1a1eae52956658a6acae6fa1b6d6c3d488192895"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "0.5.0"
+version = "0.5.1"
 
 [[Random]]
 deps = ["Serialization"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
 SpecialSets = "c6b63f46-9023-11e8-3b28-1f7d8c94880d"
 
 [extras]

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -1,4 +1,4 @@
-using DiffRules
+using DiffRules, Memoize
 
 export Rules
 export normalize
@@ -26,7 +26,7 @@ Base.vcat(rss::Rules...) = Rules([(rs.rules for rs ∈ rss)...;])
 
 
 normalize(rs::Rules) = Base.Fix2(normalize, rs)
-function normalize(t::Term, rs::Rules)
+@memoize function normalize(t::Term, rs::Rules)
     while true
         t = map(normalize(rs), t)  # FIXME: replace with `subexpressions`
         t′ = foldl(normalize, rs; init=t)


### PR DESCRIPTION
This gives some nice speed improvements for (sub)terms which are normalized many times.
```
julia> using Rewrite

julia> t  = @term((1 - 2/2)/5);

julia> t2 = @term((1 - 2/2)/5 + 1);

julia> rs = rules();

julia> normalize((@term 1 + 1), rs);

julia> @time normalize(t, rs)
  1.820396 seconds (6.22 M allocations: 317.694 MiB, 3.41% gc time)
@term(0)

julia> @time normalize(t, rs)
  0.000007 seconds (6 allocations: 224 bytes)
@term(0)

julia> @time normalize(t2, rs)
  0.006557 seconds (86.77 k allocations: 8.048 MiB)
@term(1)

julia> @time normalize(t2, rs)
  0.000007 seconds (6 allocations: 224 bytes)
@term(1)
```

Let me know if I'm doing this PR wrong. I'm targeting your branch `fix/speed` instead of master since I think this falls under PR #60. 